### PR TITLE
Make Framebuffer match alpha settings of the parent context

### DIFF
--- a/examples/simple/index.html
+++ b/examples/simple/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html><html lang="en"><head>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.4.0/p5.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.4.1/p5.min.js"></script>
     <script src="../../p5.Framebuffer.js" type="text/javascript"></script>
     <link rel="stylesheet" type="text/css" href="style.css">
     <meta charset="utf-8">

--- a/examples/simple/sketch.js
+++ b/examples/simple/sketch.js
@@ -9,6 +9,7 @@ function draw() {
   // Draw a sphere to the Framebuffer
   fbo.draw(() => {
     clear()
+    background(255)
     push()
     noStroke()
     fill(255, 0, 0)
@@ -20,6 +21,7 @@ function draw() {
 
   // Do something with fbo.color or dbo.depth
   clear()
+  background(255)
   push()
   noStroke()
   

--- a/p5.Framebuffer.js
+++ b/p5.Framebuffer.js
@@ -97,6 +97,7 @@ class Framebuffer {
     const width = this._renderer.width
     const height = this._renderer.height
     const density = this._renderer._pInst._pixelDensity
+    const hasAlpha = this._renderer._pInst._glAttributes.alpha
 
     const colorTexture = gl.createTexture()
     if (!colorTexture) {
@@ -111,11 +112,11 @@ class Framebuffer {
     gl.texImage2D(
       gl.TEXTURE_2D,
       0,
-      gl.RGBA,
+      hasAlpha ? gl.RGBA : gl.RGB,
       width * density,
       height * density,
       0,
-      gl.RGBA,
+      hasAlpha ? gl.RGBA : gl.RGB,
       gl.UNSIGNED_BYTE,
       null,
     )


### PR DESCRIPTION
Fixes https://github.com/davepagurek/p5.Framebuffer/issues/5

In p5 1.4.1, [WebGL graphics/canvases default to not having an alpha channel](https://github.com/processing/p5.js/pull/5555) to make alpha blending less confusing by default (thanks @SableRaf for finding this!) Previously, p5.Framebuffer would always have an alpha channel, leading to unexpected results in p5 1.4.1.

After this change:
- The framebuffer will create an alpha channel if and only if the WebGL context it's attached to has one
- The example sketch calls `background(255)` after `clear()`, since the behaviour of `clear()` looks different from v1.4.0 to v1.4.1 if you don't also set a background color